### PR TITLE
Sort the loaded items so the results are stable

### DIFF
--- a/metadb/count_items_needing_local_shelving_order.sql
+++ b/metadb/count_items_needing_local_shelving_order.sql
@@ -25,15 +25,15 @@ WHERE
         OR
         holdings_record__t.call_number ~ '[0-9]{3}(.[0-9]+)? [A-Z]{1,2}[0-9]{4,}.*'
     ) 
-    -- AND NOT EXISTS (
-    --     SELECT
-    --         1
-    --     FROM
-    --         folio_derived.item_notes item_notes
-    --     WHERE
-    --         item_notes.item_id = item__t.id
-    --         AND item_notes.note_type_name = 'Shelving order'
-    -- )
+    AND NOT EXISTS (
+        SELECT
+            1
+        FROM
+            folio_derived.item_notes item_notes
+        WHERE
+            item_notes.item_id = item__t.id
+            AND item_notes.note_type_name = 'Shelving order'
+    )
 ORDER BY 
     item__t.barcode
 $$

--- a/metadb/count_items_needing_local_shelving_order.sql
+++ b/metadb/count_items_needing_local_shelving_order.sql
@@ -34,7 +34,5 @@ WHERE
             item_notes.item_id = item__t.id
             AND item_notes.note_type_name = 'Shelving order'
     )
-ORDER BY 
-    item__t.barcode
 $$
 LANGUAGE SQL;

--- a/metadb/count_items_needing_local_shelving_order.sql
+++ b/metadb/count_items_needing_local_shelving_order.sql
@@ -34,5 +34,7 @@ WHERE
     --         item_notes.item_id = item__t.id
     --         AND item_notes.note_type_name = 'Shelving order'
     -- )
+ORDER BY 
+    item__t.barcode
 $$
 LANGUAGE SQL;

--- a/metadb/count_items_needing_local_shelving_order.sql
+++ b/metadb/count_items_needing_local_shelving_order.sql
@@ -25,14 +25,14 @@ WHERE
         OR
         holdings_record__t.call_number ~ '[0-9]{3}(.[0-9]+)? [A-Z]{1,2}[0-9]{4,}.*'
     ) 
-    AND NOT EXISTS (
-        SELECT
-            1
-        FROM
-            folio_derived.item_notes item_notes
-        WHERE
-            item_notes.item_id = item__t.id
-            AND item_notes.note_type_name = 'Shelving order'
-    )
+    -- AND NOT EXISTS (
+    --     SELECT
+    --         1
+    --     FROM
+    --         folio_derived.item_notes item_notes
+    --     WHERE
+    --         item_notes.item_id = item__t.id
+    --         AND item_notes.note_type_name = 'Shelving order'
+    -- )
 $$
 LANGUAGE SQL;

--- a/metadb/get_items_needing_local_shelving_order.sql
+++ b/metadb/get_items_needing_local_shelving_order.sql
@@ -35,15 +35,15 @@ WHERE
         OR
         holdings_record__t.call_number ~ '[0-9]{3}(.[0-9]+)? [A-Z]{1,2}[0-9]{4,}.*'
     ) 
-    -- AND NOT EXISTS (
-    --     SELECT
-    --         1
-    --     FROM
-    --         folio_derived.item_notes item_notes
-    --     WHERE
-    --         item_notes.item_id = item__t.id
-    --         AND item_notes.note_type_name = 'Shelving order'
-    -- )
+    AND NOT EXISTS (
+        SELECT
+            1
+        FROM
+            folio_derived.item_notes item_notes
+        WHERE
+            item_notes.item_id = item__t.id
+            AND item_notes.note_type_name = 'Shelving order'
+    )
 ORDER BY 
     item__t.barcode
 OFFSET

--- a/metadb/get_items_needing_local_shelving_order.sql
+++ b/metadb/get_items_needing_local_shelving_order.sql
@@ -44,6 +44,8 @@ WHERE
     --         item_notes.item_id = item__t.id
     --         AND item_notes.note_type_name = 'Shelving order'
     -- )
+ORDER BY 
+    item__t.barcode
 OFFSET
     query_offset
 LIMIT

--- a/metadb/get_items_needing_local_shelving_order.sql
+++ b/metadb/get_items_needing_local_shelving_order.sql
@@ -35,15 +35,15 @@ WHERE
         OR
         holdings_record__t.call_number ~ '[0-9]{3}(.[0-9]+)? [A-Z]{1,2}[0-9]{4,}.*'
     ) 
-    AND NOT EXISTS (
-        SELECT
-            1
-        FROM
-            folio_derived.item_notes item_notes
-        WHERE
-            item_notes.item_id = item__t.id
-            AND item_notes.note_type_name = 'Shelving order'
-    )
+    -- AND NOT EXISTS (
+    --     SELECT
+    --         1
+    --     FROM
+    --         folio_derived.item_notes item_notes
+    --     WHERE
+    --         item_notes.item_id = item__t.id
+    --         AND item_notes.note_type_name = 'Shelving order'
+    -- )
 OFFSET
     query_offset
 LIMIT


### PR DESCRIPTION
Without this, they are stable at offset zero but unstable with offsets around 1000+.